### PR TITLE
Add Dockerfile repository label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,7 @@ FROM alpine:3.18.4
 WORKDIR /
 COPY --from=builder /root/go/src/github.com/kube-awi/bin/manager /manager
 
+LABEL org.opencontainers.image.source https://github.com/app-net-interface/kube-awi
+
 USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
This change adds repository owner label to the existing Dockerfile so that kube-awi is automatically added to kube-awi repository packages.